### PR TITLE
Enable setting the color of the underlying text view

### DIFF
--- a/AndroidBootstrap/src/com/beardedhen/androidbootstrap/FontAwesomeText.java
+++ b/AndroidBootstrap/src/com/beardedhen/androidbootstrap/FontAwesomeText.java
@@ -254,4 +254,12 @@ public class FontAwesomeText extends FrameLayout {
 		tv.setText(icon);
 	}
 	
+	/**
+	 * Used to set the text color of the underlying text view.
+	 * @param color - Integer value representing a color resource.
+	 */
+	public void setTextColor(int color) {
+		tv.setTextColor(color);
+	}
+	
 }


### PR DESCRIPTION
By adding this function we are able to set the color of the underlying text view instead of relying solely on the XML layouts.
