### PR TITLE
Changed the default color of EditText border to a light grey

### DIFF
--- a/AndroidBootstrap/res/values/colors.xml
+++ b/AndroidBootstrap/res/values/colors.xml
@@ -2,7 +2,7 @@
 <resources>
     <color name="white">#ffffffff</color>
 	<color name="black">#ff000000</color>
-	<color name="bbutton_edittext_border">#ff808080</color>
+	<color name="bbutton_edittext_border">#ccc</color>
 	<color name="bbutton_edittext_disabled">#ffe0e0e0</color>
 	
 	<color name="bbutton_primary">#ff428bca</color>


### PR DESCRIPTION
Changed the default color of EditText to #ccc, which is a light grey. It is the same color Twitter Bootstrap uses and looks cleaner.

Before: 
![edittext_dark](https://f.cloud.github.com/assets/684942/1652309/ddf29256-5b0b-11e3-8bdb-34db12b4bf2e.jpg)
After: 
![edittext_light](https://f.cloud.github.com/assets/684942/1652294/6cf6b686-5b0b-11e3-92a5-83ef1bca6fb7.jpg)
