### PR TITLE
Set TextView width to match_parent to fix horizontal alignment

### DIFF
--- a/AndroidBootstrap/res/layout/font_awesome_text.xml
+++ b/AndroidBootstrap/res/layout/font_awesome_text.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:id="@+id/layout"
     android:orientation="horizontal">


### PR DESCRIPTION
It fix horizontal center alignment in my case.
