### PR TITLE
Remove activity from librarys AndroidManifest

### DIFF
--- a/AndroidBootstrap/AndroidManifest.xml
+++ b/AndroidBootstrap/AndroidManifest.xml
@@ -8,19 +8,6 @@
         android:minSdkVersion="7"
         android:targetSdkVersion="17" />
 
-    <application
-        android:allowBackup="true"
-        android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name" >
-        <activity
-            android:name="com.beardedhen.androidbootstrap.MainActivity"
-            android:label="@string/app_name" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
the activity definition should be only part of the example project not the library itself.

This funnily lead to some crashes with ClassNotFound exceptions. Don't know why Android tries to find this class if it is not used.
