### PR TITLE
Fix text size when FontAwesomeText uses style and text color when using color state list

### DIFF
--- a/AndroidBootstrap/src/com/beardedhen/androidbootstrap/FontAwesomeText.java
+++ b/AndroidBootstrap/src/com/beardedhen/androidbootstrap/FontAwesomeText.java
@@ -90,6 +90,7 @@ public class FontAwesomeText extends FrameLayout {
 		//text colour
 		if(a.getString(R.styleable.FontAwesomeText_android_textColor) != null){
 			tv.setTextColor(a.getColor(R.styleable.FontAwesomeText_android_textColor, R.color.bbutton_inverse));
+			tv.setTextColor(a.getColorStateList(R.styleable.FontAwesomeText_android_textColor));
 		}
 		
 		setIcon(icon);


### PR DESCRIPTION
Hi,

I was trying to style the `FontAwesomeText` with `style` attribute.

``` xml
    <com.beardedhen.androidbootstrap.FontAwesomeText
        android:layout_width="wrap_content"
        android:layout_height="wrap_content"
        android:duplicateParentState="true"
        android:id="@+id/icon"
        style="@style/MenuItemIcon"/>
```

This results in `NullPointerException` in the `FontAwesomeText.initialise` on

``` java
Matcher m = PATTERN_FONT_SIZE.matcher(xmlProvidedSize);
```

I found a solution. Instead of "regexping" the font size, obtain it as a dimension from the `TypedArray` object as following

``` java
float scaledDensity = getContext().getResources().getDisplayMetrics().scaledDensity;
fontSize = a.getDimension(R.styleable.FontAwesomeText_android_textSize, 14.0f*scaledDensity)/scaledDensity;
```

It works with the `textSize` defined implicitly in `style` and with also with the explicitly defined `textSize` after the fix.

The solution also fixes textColor when color state list is used.

Peter
