### PR TITLE
Fix #55 It caused NumberFormatException by indicating button's size

### DIFF
--- a/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapButton.java
+++ b/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapButton.java
@@ -172,7 +172,7 @@ public class BootstrapButton extends FrameLayout {
 		
 		int layoutWidth = 0;
 		if(a.getString(R.styleable.BootstrapButton_android_layout_width) != null) {
-			layoutWidth = a.getInt(R.styleable.BootstrapButton_android_layout_width, 0);
+			layoutWidth = (int) a.getDimension(R.styleable.BootstrapButton_android_layout_width, 0);
 		}
 		
 		//works even if it's fill_parent or match_parent 


### PR DESCRIPTION
It will happen NumberFormatException when indicating button's layout_width
ex. java.lang.NumberFormatException: Invalid float: "50.0dip"
