### PR TITLE
Fix setImage

### DIFF
--- a/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapCircleThumbnail.java
+++ b/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapCircleThumbnail.java
@@ -208,6 +208,7 @@ public class BootstrapCircleThumbnail extends FrameLayout
         }
         
         Bitmap roundBitmap = ImageUtils.getCircleBitmap(bitmap, widthPX, heightPX);
+        image.setVisibility(View.VISIBLE);
         image.setImageBitmap(roundBitmap);
         
         invalidate();


### PR DESCRIPTION
If no image is provided in the layout xml, the visibility is set to GONE.
SetImage needs to override it.

The result is that you can't set the image programmatically if you didn't assign an image in the layout xml.
