### PR TITLE
Fixed : enable to set BootstrapEditText's gravity

### DIFF
--- a/AndroidBootstrap/res/values/attrs.xml
+++ b/AndroidBootstrap/res/values/attrs.xml
@@ -26,6 +26,7 @@
         <attr name="android:text" />
         <attr name="android:hint" />
         <attr name="android:enabled" />
+        <attr name="android:gravity" />
     </declare-styleable>
 
     <declare-styleable name="BootstrapThumbnail">

--- a/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapEditText.java
+++ b/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapEditText.java
@@ -44,6 +44,7 @@ public class BootstrapEditText extends EditText {
     }
 
     private boolean roundedCorners = false;
+    private int gravity = Gravity.CENTER_VERTICAL;
     private TextState textState;
 
     public BootstrapEditText(Context context) {
@@ -73,6 +74,10 @@ public class BootstrapEditText extends EditText {
                 //state
                 state = a.getString(R.styleable.BootstrapEditText_be_state);
                 state = (state == null) ? "default" : state;
+
+                //gravity
+                gravity = a.getInt(R.styleable.BootstrapEditText_android_gravity, Gravity.CENTER_VERTICAL);
+                gravity = (gravity == Gravity.NO_GRAVITY) ? Gravity.CENTER_VERTICAL : gravity;
             }
         } finally {
             if (a != null) {
@@ -80,7 +85,7 @@ public class BootstrapEditText extends EditText {
             }
         }
 
-        setGravity(Gravity.CENTER_VERTICAL);
+        setGravity(gravity);
 
         if (this.isEnabled()) {
             textState = TextState.getStateFromString(state);


### PR DESCRIPTION
Hi, I find that we can't change the BootstrapEditText's gravity. So I add this function to it.