### PR TITLE
Fixed issue #108: [BootstrapButton]: Text set programmatically is not…

### DIFF
--- a/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapButton.java
+++ b/AndroidBootstrap/src/com/beardedhen/androidbootstrap/BootstrapButton.java
@@ -205,17 +205,14 @@ public class BootstrapButton extends FrameLayout {
             setTextGravity(gravity);
         }
 
-        boolean onlyIcon = true;
-
         //set the text
         if (text.length() > 0) {
             lblMiddle.setText(text);
             lblMiddle.setVisibility(View.VISIBLE);
-            onlyIcon = false;
         }
 
-        setupIconLeft(paddingA, paddingB, iconLeft, iconRight, onlyIcon);
-        setupIconRight(paddingA, paddingB, iconLeft, iconRight, onlyIcon);
+        setupIconLeft(paddingA, paddingB, iconLeft, iconRight, false);
+        setupIconRight(paddingA, paddingB, iconLeft, iconRight, false);
 
         if (iconLeft.length() > 0 && iconRight.length() > 0) {
             lblMiddle.setPadding(paddingA, 0, paddingA, 0);
@@ -278,7 +275,10 @@ public class BootstrapButton extends FrameLayout {
      * @param text - String value for what is displayed on the button
      */
     public void setText(String text) {
-        lblMiddle.setText(text);
+	    if (text.length() > 0) {
+		    lblMiddle.setText(text);
+		    lblMiddle.setVisibility(View.VISIBLE);
+	    }
     }
 
     /**


### PR DESCRIPTION
Hi!

I've created this request as fix for issue [#108]([BootstrapButton]: Text set programmatically is not visible)

The place for fix is **setText(String)** method, which actually sets the text, however so far as **lblMiddle** has visibility set to **GONE** it is not visible
Basically, if you have any text defined in the XML resource and then change it dynamically by calling **setText(String)** it works well. Hovewer, if there are no any text defined in the XML resource then this block:

```java
if (text.length() > 0) {
// ...
      lblMiddle.setVisibility(View.VISIBLE);
}
```

inside **initialise(AttributeSet attrs)** method is not called, and thus **lblMiddle** visibility still remains **GONE**

Also, I had to remove **onlyIcon** condition, because it caused incorrect padding between left icon and text (I didn't try to understand actually what is it for)

Feel free to ask any questions
Have a nice day