### PR TITLE
updated README to use implementation instead of compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Quick Start
  
  ```java
  dependencies {
-    compile 'com.beardedhen:androidbootstrap:{X.X.X}'
+    implementation 'com.beardedhen:androidbootstrap:{X.X.X}'
  }
  ```
  


### PR DESCRIPTION
Google depreciated compile and now reccomends using implementation when adding gradle dependencies.

I updated the readme to reflect this change.